### PR TITLE
Add Issue template and Nightly/Developer builds via GitHub Actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/code_issue.md
+++ b/.github/ISSUE_TEMPLATE/code_issue.md
@@ -1,0 +1,10 @@
+---
+name: Code Issue
+about: Give an issue about the menu's code
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Do not send an issue about bugs in the menu itself. The place to submit bugs is the discord server**

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,36 @@
+name: CMake
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+       submodules: recursive
+  
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -A win32
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j 4
+
+    - name: Artifact
+      uses: actions/upload-artifact@v3
+      with:
+       name: Nightly
+       path: ${{github.workspace}}/build/Release/GDMO.dll


### PR DESCRIPTION
Based on pr #13

> Basically, it uses GitHub Actions so that every time a commit is pushed, it will build that and upload the output as an artifact, it makes it easy for people who want to use the most recent stuff without having to build it themselves. Generally, most repos I've seen have something like this, so it would be nice to have it here.

Also adds the issue template back.