### PR TITLE
Add Links for discord when reporting an issue and extend default issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/code_issue.md
+++ b/.github/ISSUE_TEMPLATE/code_issue.md
@@ -1,10 +1,10 @@
 ---
-name: Code Issue
-about: Give an issue about the menu's code
+name: Code Review
+about: Give an issue about the menu's source code
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-**Do not send an issue about bugs in the menu itself. The place to submit bugs is the discord server**
+**Note: It's preferred if you post your code review in the Merge request (if there is one) instead of here if possible.**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issue_enabled: false
+
+contact_links:
+  - name: Feature requests
+    url: https://discord.gg/nbDjEg7SSU
+    about: Please submit feature proposals in the discord server, not here.
+
+  - name: Bug report
+    url: https://discord.gg/nbDjEg7SSU
+    about: Please submit bug reports in the discord server, not here.


### PR DESCRIPTION
With this pr, there will be 2 more option when reporting an issue.

- Bug reports: Please submit bug reports in the discord server, not here.
- Feature requests: Please submit feature proposals in the discord server, not here.

Also renames the default issue template to "Code Review".