### PR TITLE
Fix: tidy things up

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -1,5 +1,5 @@
 {
-	"geode": "2.0.0",
+	"geode": "2.0.0-beta.25",
 	"gd": {
 		"win": "2.204"
 	},
@@ -22,7 +22,7 @@
 	"dependencies": [
 		{
             "id": "geode.node-ids",
-            "version": ">=v1.7.1",
+            "version": ">=v1.9.1",
             "importance": "required"
         }
 	]

--- a/src/Hacks/EndLevelLayerInfo.cpp
+++ b/src/Hacks/EndLevelLayerInfo.cpp
@@ -238,6 +238,7 @@ class $modify(EndLevelLayer)
 		);
 		noclipAccuracyLabelELL->limitLabelWidth(180.f, .8f, .5f);
 		noclipAccuracyLabelELL->setPosition({ textPosition.x + 80.f, textPosition.y + 15.f });
+		noclipAccuracyLabelELL->setID("noclip-accuracy-label"_spr);
 		layer->addChild(noclipAccuracyLabelELL);
 
 		auto noclipDeathsLabelELL = CCLabelBMFont::create(
@@ -246,6 +247,7 @@ class $modify(EndLevelLayer)
 		);
 		noclipDeathsLabelELL->limitLabelWidth(180.f, .8f, .5f);
 		noclipDeathsLabelELL->setPosition({ textPosition.x + 80.f, textPosition.y - 15.f });
+		noclipDeathsLabelELL->setID("noclip-deaths-label"_spr);
 		layer->addChild(noclipDeathsLabelELL);
 	}
 };


### PR DESCRIPTION
- add node IDs to endlevellayer noclip accuracy/death labels
- actually get the workflow to build this time (say goodbye to `"geode": "2.0.0"`)